### PR TITLE
Adds feature for DualShock 4 support

### DIFF
--- a/src/PCGWGame.cs
+++ b/src/PCGWGame.cs
@@ -95,6 +95,14 @@ namespace PCGamingWikiMetadata
             }
         }
 
+        public void AddDualShock4Support(string description)
+        {
+            if (description == PCGamingWikiType.Rating.NativeSupport)
+            {
+                this.AddFeature("DualShock 4");
+            }
+        }
+
         public void AddTouchscreenSupport(string description)
         {
             if (description == PCGamingWikiType.Rating.NativeSupport)

--- a/src/PCGamingWikiHTMLParser.cs
+++ b/src/PCGamingWikiHTMLParser.cs
@@ -228,6 +228,9 @@ namespace PCGamingWikiMetadata
                                 case "Touchscreen optimised":
                                     this.gameController.Game.AddTouchscreenSupport(child.FirstChild.Attributes["title"].Value);
                                     break;
+                                case "DualShock 4 controllers":
+                                    this.gameController.Game.AddDualShock4Support(child.FirstChild.Attributes["title"].Value);
+                                    break;
                                 default:
                                     break;
 


### PR DESCRIPTION
**Description**
Adds a DualShock 4 feature for games that have native support for DualShock 4 controllers. This addresses https://github.com/sharkusmanch/playnite-pcgamingwiki-metadata-provider/issues/41

**Testing Performed**
I ran this on my library and confirmed that I was seeing the DualShock 4 feature show up where I expect it (and therefore my scripting for DS4Windows profiles works automatically now)