### PR TITLE
Fixes support for detecting PlayStation controllers

### DIFF
--- a/src/Localization/en_US.xaml
+++ b/src/Localization/en_US.xaml
@@ -20,6 +20,7 @@
     <sys:String x:Key="LOCPCGWSettingsOtherTags">Other Tags</sys:String>
     <sys:String x:Key="LOCPCGWSettingsOtherFeatures">Other Features</sys:String>
     <sys:String x:Key="LOCPCGWSettingsVideoFeatures">Video Features</sys:String>
+    <sys:String x:Key="LOCPCGWSettingsControllerFeatures">Controller Features</sys:String>
     <sys:String x:Key="LOCPCGWSettingsFeatureHDR">HDR</sys:String>
     <sys:String x:Key="LOCPCGWSettingsImportHDR">HDR</sys:String>
     <sys:String x:Key="LOCPCGWSettingsImportRayTracing">Ray Tracing</sys:String>
@@ -33,6 +34,12 @@
     <sys:String x:Key="LOCPCGWSettingsImportVROculusRift">Oculus Rift</sys:String>
     <sys:String x:Key="LOCPCGWSettingsFeatureRayTracing">Ray Tracing</sys:String>
     <sys:String x:Key="LOCPCGWSettingsImportMultiplayerTypes">Add detailed multiplayer features</sys:String>
+    <sys:String x:Key="LOCPCGWSettingsImportPlayStationControllers">PlayStation Controllers</sys:String>
+    <sys:String x:Key="LOCPCGWSettingsImportPlayStationButtonPrompts">PlayStation Button Prompts</sys:String>
+    <sys:String x:Key="LOCPCGWSettingsImportLightBar">Light Bar Support</sys:String>
+    <sys:String x:Key="LOCPCGWSettingsImportAdaptiveTrigger">Adaptive Trigger Support</sys:String>
+    <sys:String x:Key="LOCPCGWSettingsImportHapticFeedback">Haptic Feedback Support</sys:String>
+
     <sys:String x:Key="LOCPCGWSettingsTabTagPrefix">Tag Prefix</sys:String>
     <sys:String x:Key="LOCPCGWSettingsTabLinks">Links</sys:String>
 

--- a/src/PCGWClient.cs
+++ b/src/PCGWClient.cs
@@ -84,7 +84,7 @@ namespace PCGamingWikiMetadata
                 {
                     if (!((string)game.snippet).Contains("#REDIRECT"))
                     {
-                        PCGWGame g = new PCGWGame((string)game.title, (int)game.pageid);
+                        PCGWGame g = new PCGWGame(gameController.Settings, (string)game.title, (int)game.pageid);
                         gameResults.Add(g);
                     }
                 }

--- a/src/PCGWGame.cs
+++ b/src/PCGWGame.cs
@@ -12,6 +12,8 @@ namespace PCGamingWikiMetadata
         private readonly ILogger logger = LogManager.GetLogger();
         public int PageID { get; set; }
 
+        private PCGamingWikiMetadataSettings settings;
+
         private List<MetadataProperty> genres;
         public List<MetadataProperty> Genres { get { return genres; } }
         private List<MetadataProperty> developers;
@@ -32,8 +34,9 @@ namespace PCGamingWikiMetadata
 
         public Game LibraryGame;
 
-        public PCGWGame()
+        public PCGWGame(PCGamingWikiMetadataSettings settings)
         {
+            this.settings = settings;
             this.links = new List<Link>();
             this.genres = new List<MetadataProperty>();
             this.features = new List<MetadataProperty>();
@@ -45,7 +48,7 @@ namespace PCGamingWikiMetadata
             this.reception = new Dictionary<string, int?>();
         }
 
-        public PCGWGame(string name, int pageid) : this()
+        public PCGWGame(PCGamingWikiMetadataSettings settings, string name, int pageid) : this(settings)
         {
             this.Name = name;
             this.PageID = pageid;
@@ -95,11 +98,68 @@ namespace PCGamingWikiMetadata
             }
         }
 
-        public void AddDualShock4Support(string description)
+        public void AddPlayStationControllerSupport(string description)
         {
+            if (!this.settings.ImportFeaturePlayStationControllers)
+            {
+                return;
+            }
+
             if (description == PCGamingWikiType.Rating.NativeSupport)
             {
-                this.AddFeature("DualShock 4");
+                this.AddFeature("PlayStation Controller");
+            }
+        }
+
+        public void AddPlayStationButtonPrompts(string description)
+        {
+            if (!this.settings.ImportFeaturePlayStationButtonPrompts)
+            {
+                return;
+            }
+
+            if (description == PCGamingWikiType.Rating.NativeSupport)
+            {
+                this.AddFeature("PlayStation Button Prompts");
+            }
+        }
+
+        public void AddLightBarSupport(string description)
+        {
+            if (!this.settings.ImportFeatureLightBar)
+            {
+                return;
+            }
+
+            if (description == PCGamingWikiType.Rating.NativeSupport)
+            {
+                this.AddFeature("Light Bar Support");
+            }
+        }
+
+        public void AddAdaptiveTriggerSupport(string description)
+        {
+            if (!this.settings.ImportFeatureAdaptiveTrigger)
+            {
+                return;
+            }
+
+            if (description == PCGamingWikiType.Rating.NativeSupport)
+            {
+                this.AddFeature("Adaptive Trigger Support");
+            }
+        }
+
+        public void AddHapticFeedbackSupport(string description)
+        {
+            if (!this.settings.ImportFeatureHapticFeedback)
+            {
+                return;
+            }
+
+            if (description == PCGamingWikiType.Rating.NativeSupport)
+            {
+                this.AddFeature("Haptic Feedback Support");
             }
         }
 

--- a/src/PCGamingWikiHTMLParser.cs
+++ b/src/PCGamingWikiHTMLParser.cs
@@ -228,8 +228,20 @@ namespace PCGamingWikiMetadata
                                 case "Touchscreen optimised":
                                     this.gameController.Game.AddTouchscreenSupport(child.FirstChild.Attributes["title"].Value);
                                     break;
-                                case "DualShock 4 controllers":
-                                    this.gameController.Game.AddDualShock4Support(child.FirstChild.Attributes["title"].Value);
+                                case "PlayStation controllers":
+                                    this.gameController.Game.AddPlayStationControllerSupport(child.FirstChild.Attributes["title"].Value);
+                                    break;
+                                case "PlayStation button prompts":
+                                    this.gameController.Game.AddPlayStationButtonPrompts(child.FirstChild.Attributes["title"].Value);
+                                    break;
+                                case "Light bar support":
+                                    this.gameController.Game.AddLightBarSupport(child.FirstChild.Attributes["title"].Value);
+                                    break;
+                                case "Adaptive trigger support":
+                                    this.gameController.Game.AddAdaptiveTriggerSupport(child.FirstChild.Attributes["title"].Value);
+                                    break;
+                                case "DualSense haptic feedback support":
+                                    this.gameController.Game.AddHapticFeedbackSupport(child.FirstChild.Attributes["title"].Value);
                                     break;
                                 default:
                                     break;

--- a/src/PCGamingWikiMetadataProvider.cs
+++ b/src/PCGamingWikiMetadataProvider.cs
@@ -78,7 +78,7 @@ namespace PCGamingWikiMetadata
                 }
                 else
                 {
-                    this.gameController.Game = new PCGWGame();
+                    this.gameController.Game = new PCGWGame((PCGamingWikiMetadataSettings)this.plugin.GetSettings(false));
                     logger.Warn($"Cancelled search");
                 }
             }
@@ -90,7 +90,7 @@ namespace PCGamingWikiMetadata
 
                     if (results.Count == 0)
                     {
-                        this.gameController.Game = new PCGWGame();
+                        this.gameController.Game = new PCGWGame((PCGamingWikiMetadataSettings)this.plugin.GetSettings(false));
                         return;
                     }
 

--- a/src/PCGamingWikiMetadataSettings.cs
+++ b/src/PCGamingWikiMetadataSettings.cs
@@ -72,7 +72,22 @@ namespace PCGamingWikiMetadata
         public bool ImportFeatureVRWMR { get { return importFeatureVRWMR; } set { importFeatureVRWMR = value; ; NotifyPropertyChanged("ImportFeatureVRWMR"); } }
         private bool importFeatureVRvorpX = false;
         public bool ImportFeatureVRvorpX { get { return importFeatureVRvorpX; } set { importFeatureVRvorpX = value; ; NotifyPropertyChanged("ImportFeatureVRvorpX"); } }
+        
+        private bool importFeaturePlayStationControllers = false;
+        public bool ImportFeaturePlayStationControllers { get { return importFeaturePlayStationControllers; } set { importFeaturePlayStationControllers = value; ; NotifyPropertyChanged(nameof(ImportFeaturePlayStationControllers)); } }
 
+        private bool importFeaturePlayStationButtonPrompts = false;
+        public bool ImportFeaturePlayStationButtonPrompts { get { return importFeaturePlayStationButtonPrompts; } set { importFeaturePlayStationButtonPrompts = value; ; NotifyPropertyChanged(nameof(ImportFeaturePlayStationButtonPrompts)); } }
+
+        private bool importFeatureLightBar = false;
+        public bool ImportFeatureLightBar { get { return importFeatureLightBar; } set { importFeatureLightBar = value; ; NotifyPropertyChanged(nameof(ImportFeatureLightBar)); } }
+
+        private bool importFeatureAdaptiveTrigger = false;
+        public bool ImportFeatureAdaptiveTrigger { get { return importFeatureAdaptiveTrigger; } set { importFeatureAdaptiveTrigger = value; ; NotifyPropertyChanged(nameof(ImportFeatureAdaptiveTrigger)); } }
+
+        private bool importFeatureHapticFeedback = false;
+        public bool ImportFeatureHapticFeedback { get { return importFeatureHapticFeedback; } set { importFeatureHapticFeedback = value; ; NotifyPropertyChanged(nameof(ImportFeatureHapticFeedback)); } }
+        
         private string tagPrefixMonetization = $"[{ResourceProvider.GetString("LOCPCGWSettingsTagPrefixMonetization")}]";
         public string TagPrefixMonetization { get { return tagPrefixMonetization; } set { tagPrefixMonetization = value; ; NotifyPropertyChanged("TagPrefixMonetization"); } }
         private string tagPrefixMicrotransactions = $"[{ResourceProvider.GetString("LOCPCGWSettingsTagPrefixMicrotransactions")}]";
@@ -162,6 +177,12 @@ namespace PCGamingWikiMetadata
                 ImportFeatureVROSVR = savedSettings.importFeatureVROSVR;
                 ImportFeatureVRWMR = savedSettings.importFeatureVRWMR;
 
+                ImportFeaturePlayStationControllers = savedSettings.importFeaturePlayStationControllers;
+                ImportFeaturePlayStationButtonPrompts = savedSettings.ImportFeaturePlayStationButtonPrompts;
+                ImportFeatureLightBar = savedSettings.ImportFeatureLightBar;
+                ImportFeatureAdaptiveTrigger = savedSettings.importFeatureAdaptiveTrigger;
+                ImportFeatureHapticFeedback = savedSettings.importFeatureHapticFeedback;
+                
                 TagPrefixMonetization = savedSettings.tagPrefixMonetization;
                 TagPrefixMicrotransactions = savedSettings.tagPrefixMicrotransactions;
                 TagPrefixPacing = savedSettings.tagPrefixPacing;

--- a/src/PCGamingWikiMetadataSettings.cs
+++ b/src/PCGamingWikiMetadataSettings.cs
@@ -72,7 +72,7 @@ namespace PCGamingWikiMetadata
         public bool ImportFeatureVRWMR { get { return importFeatureVRWMR; } set { importFeatureVRWMR = value; ; NotifyPropertyChanged("ImportFeatureVRWMR"); } }
         private bool importFeatureVRvorpX = false;
         public bool ImportFeatureVRvorpX { get { return importFeatureVRvorpX; } set { importFeatureVRvorpX = value; ; NotifyPropertyChanged("ImportFeatureVRvorpX"); } }
-        
+
         private bool importFeaturePlayStationControllers = false;
         public bool ImportFeaturePlayStationControllers { get { return importFeaturePlayStationControllers; } set { importFeaturePlayStationControllers = value; ; NotifyPropertyChanged(nameof(ImportFeaturePlayStationControllers)); } }
 
@@ -87,7 +87,7 @@ namespace PCGamingWikiMetadata
 
         private bool importFeatureHapticFeedback = false;
         public bool ImportFeatureHapticFeedback { get { return importFeatureHapticFeedback; } set { importFeatureHapticFeedback = value; ; NotifyPropertyChanged(nameof(ImportFeatureHapticFeedback)); } }
-        
+
         private string tagPrefixMonetization = $"[{ResourceProvider.GetString("LOCPCGWSettingsTagPrefixMonetization")}]";
         public string TagPrefixMonetization { get { return tagPrefixMonetization; } set { tagPrefixMonetization = value; ; NotifyPropertyChanged("TagPrefixMonetization"); } }
         private string tagPrefixMicrotransactions = $"[{ResourceProvider.GetString("LOCPCGWSettingsTagPrefixMicrotransactions")}]";
@@ -182,7 +182,7 @@ namespace PCGamingWikiMetadata
                 ImportFeatureLightBar = savedSettings.ImportFeatureLightBar;
                 ImportFeatureAdaptiveTrigger = savedSettings.importFeatureAdaptiveTrigger;
                 ImportFeatureHapticFeedback = savedSettings.importFeatureHapticFeedback;
-                
+
                 TagPrefixMonetization = savedSettings.tagPrefixMonetization;
                 TagPrefixMicrotransactions = savedSettings.tagPrefixMicrotransactions;
                 TagPrefixPacing = savedSettings.tagPrefixPacing;

--- a/src/PCGamingWikiMetadataSettingsView.xaml
+++ b/src/PCGamingWikiMetadataSettingsView.xaml
@@ -87,6 +87,70 @@
                 <StackPanel Margin="5">
                     <CheckBox IsChecked="{Binding ImportFeatureUltrawide}" Content="{DynamicResource LOCPCGWSettingsImportUltrawide}"/>
                 </StackPanel>
+
+                <Label Margin="5" Height="25" Content="{DynamicResource LOCPCGWSettingsControllerFeatures}"/>
+                <StackPanel Margin="0">
+                    <Expander Grid.Row="0">
+                        <Expander.Style>
+                            <Style TargetType="{x:Type Expander}" BasedOn="{StaticResource {x:Type Expander}}">
+                                <Setter Property="Background" Value="Transparent" />
+                            </Style>
+                        </Expander.Style>
+
+                        <Expander.Header>
+                            <Grid>
+                                <CheckBox Grid.Column="0" Grid.Row="0" IsChecked="{Binding ImportFeaturePlayStationControllers}" VerticalAlignment="Center">
+                                    <Label Content="{DynamicResource LOCPCGWSettingsImportPlayStationControllers}"></Label>
+                                </CheckBox>
+                            </Grid>
+                        </Expander.Header>
+
+                        <Expander.Content>
+                            <Border Margin="0" Padding="0">
+                                <Grid>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="auto" />
+                                        <RowDefinition Height="4" />
+                                        <RowDefinition Height="auto" />
+
+                                        <RowDefinition Height="auto" />
+                                        <RowDefinition Height="4" />
+                                        <RowDefinition Height="auto" />
+
+                                        <RowDefinition Height="auto" />
+                                        <RowDefinition Height="4" />
+                                        <RowDefinition Height="auto" />
+
+                                        <RowDefinition Height="auto" />
+                                        <RowDefinition Height="4" />
+                                        <RowDefinition Height="auto" />
+
+                                        <RowDefinition Height="auto" />
+                                        <RowDefinition Height="4" />
+                                        <RowDefinition Height="auto" />
+                                    </Grid.RowDefinitions>
+
+                                    <CheckBox Grid.Row="0" Padding="4" IsChecked="{Binding ImportFeaturePlayStationButtonPrompts}">
+                                        <Label Content="{DynamicResource LOCPCGWSettingsImportPlayStationButtonPrompts}" />
+                                    </CheckBox>
+
+                                    <CheckBox Grid.Row="3" Padding="4" IsChecked="{Binding ImportFeatureLightBar}">
+                                        <Label Content="{DynamicResource LOCPCGWSettingsImportLightBar}" />
+                                    </CheckBox>
+
+                                    <CheckBox Grid.Row="6" Padding="4" IsChecked="{Binding ImportFeatureAdaptiveTrigger}">
+                                        <Label Content="{DynamicResource LOCPCGWSettingsImportAdaptiveTrigger}" />
+                                    </CheckBox>
+
+                                    <CheckBox Grid.Row="9" Padding="4" IsChecked="{Binding ImportFeatureHapticFeedback}">
+                                        <Label Content="{DynamicResource LOCPCGWSettingsImportHapticFeedback}" />
+                                    </CheckBox>
+                                </Grid>
+                            </Border>
+                        </Expander.Content>
+                    </Expander>
+                </StackPanel>
+
                 <Label Margin="5" Height="25" Content="{DynamicResource LOCPCGWSettingsOtherFeatures}"/>
                 <StackPanel Margin="15">
                     <CheckBox IsChecked="{Binding ImportXboxPlayAnywhere}" Content="{DynamicResource LOCPCGWSettingsImportXboxPlayAnywhere}"/>

--- a/tests/PCGWGame_Test_AC_INDIA.cs
+++ b/tests/PCGWGame_Test_AC_INDIA.cs
@@ -12,10 +12,10 @@ public class PCGWGame_Test_AC_INDIA : IDisposable
 
     public PCGWGame_Test_AC_INDIA()
     {
-        this.testGame = new PCGWGame("ac_chronicles_india", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceBattleNet();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "ac_chronicles_india", -1);
         this.client.FetchGamePageContent(this.testGame);
     }
 

--- a/tests/PCGWGame_Test_BAT.cs
+++ b/tests/PCGWGame_Test_BAT.cs
@@ -13,10 +13,10 @@ public class PCGWGame_Test_BAT : IDisposable
 
     public PCGWGame_Test_BAT()
     {
-        this.testGame = new PCGWGame("batman_ak", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceEpic();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "batman_ak", -1);
         this.client.GetSettings().ImportTagNoCloudSaves = false;
         this.client.GetSettings().ImportFeatureFramerate60 = true;
         this.client.GetSettings().ImportFeatureFramerate120 = true;

--- a/tests/PCGWGame_Test_CATLADY.cs
+++ b/tests/PCGWGame_Test_CATLADY.cs
@@ -13,10 +13,10 @@ public class PCGWGame_Test_CATLADY : IDisposable
 
     public PCGWGame_Test_CATLADY()
     {
-        this.testGame = new PCGWGame("cat_lady", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceSteam();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "cat_lady", -1);
         // this.client.GetSettings().ImportTagNoCloudSaves = false;
         // this.client.GetSettings().ImportFeatureFramerate60 = true;
         // this.client.GetSettings().ImportFeatureFramerate120 = true;

--- a/tests/PCGWGame_Test_CITIES.cs
+++ b/tests/PCGWGame_Test_CITIES.cs
@@ -12,10 +12,10 @@ public class PCGWGame_Test_CITIES : IDisposable
 
     public PCGWGame_Test_CITIES()
     {
-        this.testGame = new PCGWGame("cities", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceSteam();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "cities", -1);
         this.client.GetSettings().ImportLinkOfficialSite = false;
         this.client.FetchGamePageContent(this.testGame);
     }

--- a/tests/PCGWGame_Test_CODMW.cs
+++ b/tests/PCGWGame_Test_CODMW.cs
@@ -12,10 +12,10 @@ public class PCGWGame_Test_CODMW : IDisposable
 
     public PCGWGame_Test_CODMW()
     {
-        this.testGame = new PCGWGame("codmw", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceBattleNet();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "codmw", -1);
         this.client.GetSettings().ImportMultiplayerTypes = true;
         this.client.GetSettings().ImportFeatureVR = true;
         this.client.GetSettings().ImportFeatureHDR = true;

--- a/tests/PCGWGame_Test_CODMW_nomulti.cs
+++ b/tests/PCGWGame_Test_CODMW_nomulti.cs
@@ -12,10 +12,10 @@ public class PCGWGame_Test_CODMW_nomulti : IDisposable
 
     public PCGWGame_Test_CODMW_nomulti()
     {
-        this.testGame = new PCGWGame("codmw", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceBattleNet();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "codmw", -1);
         this.client.GetSettings().ImportMultiplayerTypes = false;
         this.client.GetSettings().ImportFeatureHDR = false;
         this.client.GetSettings().ImportFeatureRayTracing = false;

--- a/tests/PCGWGame_Test_DL.cs
+++ b/tests/PCGWGame_Test_DL.cs
@@ -11,8 +11,8 @@ public class PCGWGame_Test_DL : IDisposable
 
     public PCGWGame_Test_DL()
     {
-        this.testGame = new PCGWGame("deathloop", -1);
         this.client = new LocalPCGWClient();
+        this.testGame = new PCGWGame(this.client.GetSettings(), "deathloop", -1);
         this.client.GetSettings().ImportMultiplayerTypes = true;
         this.client.GetSettings().ImportFeatureVR = true;
         this.client.FetchGamePageContent(this.testGame);

--- a/tests/PCGWGame_Test_DQ11.cs
+++ b/tests/PCGWGame_Test_DQ11.cs
@@ -12,10 +12,10 @@ public class PCGWGame_Test_DQ11 : IDisposable
 
     public PCGWGame_Test_DQ11()
     {
-        this.testGame = new PCGWGame("dq11", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceXbox();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "dq11", -1);
 
         this.client.GetSettings().ImportTagEngine = false;
         this.client.GetSettings().ImportTagArtStyle = false;

--- a/tests/PCGWGame_Test_LMS.cs
+++ b/tests/PCGWGame_Test_LMS.cs
@@ -7,12 +7,12 @@ using FluentAssertions;
 public class PCGWGame_Test_LMS : IDisposable
 {
     private PCGWGame testGame;
-    private PCGWClient client;
+    private LocalPCGWClient client;
 
     public PCGWGame_Test_LMS()
     {
-        this.testGame = new PCGWGame("LMS", -1);
         this.client = new LocalPCGWClient();
+        this.testGame = new PCGWGame(this.client.GetSettings(), "LMS", -1);
         this.client.FetchGamePageContent(this.testGame);
     }
 

--- a/tests/PCGWGame_Test_Lego_HP.cs
+++ b/tests/PCGWGame_Test_Lego_HP.cs
@@ -13,10 +13,10 @@ public class PCGWGame_Test_Lego_HP : IDisposable
 
     public PCGWGame_Test_Lego_HP()
     {
-        this.testGame = new PCGWGame("lhp", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceSteam();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "lhp", -1);
         this.client.GetSettings().ImportTagNoCloudSaves = true;
         this.client.GetSettings().ImportFeatureVR = true;
         this.client.GetSettings().ImportFeatureFramerate60 = true;

--- a/tests/PCGWGame_Test_OVERCOOKED.cs
+++ b/tests/PCGWGame_Test_OVERCOOKED.cs
@@ -12,10 +12,10 @@ public class PCGWGame_Test_OVERCOOKED : IDisposable
 
     public PCGWGame_Test_OVERCOOKED()
     {
-        this.testGame = new PCGWGame("overcooked", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceOrigin();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "overcooked", -1);
         this.client.GetSettings().ImportFeatureVR = true;
         this.client.GetSettings().ImportMultiplayerTypes = true;
         this.client.FetchGamePageContent(this.testGame);

--- a/tests/PCGWGame_Test_REG_BBALL.cs
+++ b/tests/PCGWGame_Test_REG_BBALL.cs
@@ -13,10 +13,10 @@ public class PCGWGame_Test_REG_BBALL : IDisposable
 
     public PCGWGame_Test_REG_BBALL()
     {
-        this.testGame = new PCGWGame("reg_bball", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceEpic();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "reg_bball", -1);
         this.client.GetSettings().ImportMultiplayerTypes = true;
         this.client.GetSettings().ImportFeatureFramerate60 = true;
         this.client.GetSettings().ImportFeatureFramerate120 = true;

--- a/tests/PCGWGame_Test_SKYRIMVR.cs
+++ b/tests/PCGWGame_Test_SKYRIMVR.cs
@@ -13,10 +13,10 @@ public class PCGWGame_Test_SKYRIMVR : IDisposable
 
     public PCGWGame_Test_SKYRIMVR()
     {
-        this.testGame = new PCGWGame("skyrimvr", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceSteam();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "skyrimvr", -1);
         this.client.GetSettings().ImportFeatureVR = true;
         this.client.FetchGamePageContent(this.testGame);
     }

--- a/tests/PCGWGame_Test_SOH.cs
+++ b/tests/PCGWGame_Test_SOH.cs
@@ -7,12 +7,12 @@ using FluentAssertions;
 public class PCGWGame_Test_SOH : IDisposable
 {
     private PCGWGame testGame;
-    private PCGWClient client;
+    private LocalPCGWClient client;
 
     public PCGWGame_Test_SOH()
     {
-        this.testGame = new PCGWGame("songofhorror", -1);
         this.client = new LocalPCGWClient();
+        this.testGame = new PCGWGame(this.client.GetSettings(), "songofhorror", -1);
         this.client.FetchGamePageContent(this.testGame);
     }
 

--- a/tests/PCGWGame_Test_WH_40K_SPACE_MARINE.cs
+++ b/tests/PCGWGame_Test_WH_40K_SPACE_MARINE.cs
@@ -12,10 +12,10 @@ public class PCGWGame_Test_WH_40K_SPACE_MARINE : IDisposable
 
     public PCGWGame_Test_WH_40K_SPACE_MARINE()
     {
-        this.testGame = new PCGWGame("wh_40k_space_marine", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceBattleNet();
         this.client = new LocalPCGWClient(this.options);
+        this.testGame = new PCGWGame(this.client.GetSettings(), "wh_40k_space_marine", -1);
         this.client.FetchGamePageContent(this.testGame);
     }
 

--- a/tests/PCGWGame_Test_YAKUZA4.cs
+++ b/tests/PCGWGame_Test_YAKUZA4.cs
@@ -14,11 +14,10 @@ public class PCGWGame_Test_YAKUZA4 : IDisposable
 
     public PCGWGame_Test_YAKUZA4()
     {
-        this.testGame = new PCGWGame("yakuza4", -1);
         this.options = new TestMetadataRequestOptions();
         this.options.SetGameSourceXbox();
         this.client = new LocalPCGWClient(this.options);
-
+        this.testGame = new PCGWGame(this.client.GetSettings(), "yakuza4", -1);
         // Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
 
         this.client.GetSettings().AddTagPrefix = false;


### PR DESCRIPTION
PCGamingWiki changed their DualShock 4 feature to a general PlayStation controllers feature. This now allows Playnite to correctly detect PlayStation controllers again. See https://github.com/sharkusmanch/playnite-pcgamingwiki-metadata-provider/issues/89

In addition, I added detection for sub-features of playstation controllers within games, specifically
* PlayStation button prompts
* Light bar support
* adaptive triggers
* haptic feedback

All PlayStation controller features are configurable within the plugin settings for those that are not interested in cluttering their game features with PlayStation-related features.
<img width="665" alt="image" src="https://github.com/sharkusmanch/playnite-pcgamingwiki-metadata-provider/assets/6503344/866af7a0-3d37-4522-ac23-f7f4d68b2e61">
